### PR TITLE
Update Dockerfile and add mutliarch support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:bookworm-slim
+
+RUN apt update -y
+RUN apt install -y \
+      gcc \
+      nasm \
+      make \
+      gcc-x86-64-linux-gnu \
+      binutils-x86-64-linux-gnu \
+      qemu-utils
+
+WORKDIR /src

--- a/Kernel/Makefile.inc
+++ b/Kernel/Makefile.inc
@@ -1,6 +1,6 @@
-GCC=gcc
-LD=ld
-AR=ar
+GCC=x86_64-linux-gnu-gcc
+LD=x86_64-linux-gnu-ld
+AR=x86_64-linux-gnu-ar
 ASM=nasm
 
 GCCFLAGS=-m64 -fno-exceptions -fno-asynchronous-unwind-tables -mno-mmx -mno-sse -mno-sse2 -fno-builtin-malloc -fno-builtin-free -fno-builtin-realloc -mno-red-zone -Wall -ffreestanding -nostdlib -fno-common -std=c99

--- a/Userland/Makefile.inc
+++ b/Userland/Makefile.inc
@@ -1,7 +1,7 @@
-GCC=gcc
-GPP=g++
-LD=ld
-AR=ar
+GCC=x86_64-linux-gnu-gcc
+GPP=x86_64-linux-gnu-g++
+LD=x86_64-linux-gnu-ld
+AR=x86_64-linux-gnu-ar
 ASM=nasm
 
 GCCFLAGS=-m64 -fno-exceptions -std=c99 -Wall -ffreestanding -nostdlib -fno-common -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -fno-builtin-malloc -fno-builtin-free -fno-builtin-realloc


### PR DESCRIPTION
## Descripción

- Agrego Dockerfile basado en la ultima version estable de Debian. El mismo tiene los paquetes  `gcc-x86-64-linux-gnu` y `binutils-x86-64-linux-gnu` que tienen x86-64 como arquitectura target. En los repos de Debian hay builds tanto para amd64 como para arm64 de ambos paquetes. Esto hace que sin importar en que arquitectura host este corriendo Docker, el binario generado siempre tiene como target x86-64 (amd64).
- Cambio los `Makefile.inc` de Kernel y Userland para que compilen con `x86_64-linux-gnu-gcc` y linkediten con `x86_64-linux-gnu-ld`.

**Nota:** el Module Packer (dentro de Toolchain) lo seguimos compilando con gcc para que lo compile para la arquitectura host, ya que lo vamos a correr en la misma. Lo mismo pasa con BMFS que esta en Bootloader.